### PR TITLE
Reorder lint and audit add condition for threshold

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -25,8 +25,9 @@ jobs:
       - run: |
           cd frontend 
           yarn --frozen-lockfile
-          yarn audit
           yarn lint:ci
+          yarn audit
+          if [ $? -lt 16 ]; then exit 0; else exit 1; fi
   security-api:
     name: Security of api 
     runs-on: ubuntu-20.04
@@ -40,8 +41,9 @@ jobs:
       - run: |
           cd api
           yarn --frozen-lockfile
+          yarn lint:ci
           yarn audit
-          yarn lint:ci 
+          if [ $? -lt 16 ]; then exit 0; else exit 1; fi
   security-initial-data-load:
     name: Security of initial-data-load
     runs-on: ubuntu-20.04
@@ -55,8 +57,9 @@ jobs:
       - run: |
           cd initial-data-load
           yarn --frozen-lockfile
+          yarn lint:ci
           yarn audit
-          yarn lint:ci 
+          if [ $? -lt 16 ]; then exit 0; else exit 1; fi
   # Test jobs
   test-api:
     name: Test API


### PR DESCRIPTION
## Description

For the security jobs, I reordered yarn lint over yarn audit, because a failure in yarn audit will exit the console before yarn lint can be performed. 

I also added a condition that any yarn audit exit code less than 16, which means severe vulnerability, will exit as 0 since this is the threshold of security acceptance for now. This will allow frontend security job to succeed for now until the code has fixed the security problems.

## Motivation and Context

Fixes issue #54 by having a threshold set in the Github YAML file using Bash after yarn audit.

## How has this been tested?

Tested this in a separate pipeline on a different project with the same requirements. Will be tested on Github Actions before it is merged to main.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have checked to ensure that there aren't other open [Pull Requests](../../../pulls) for the same update/change.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
