### PR TITLE
89 show multiple regions layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- 'timeseries' key on the top level is now deprecated and moved to 'layerOptions' key. New 'layerOptions' key should be defined in ./initial-data-load/data/{country}/MapLayers.yml configuration file on the top level and 'timeseries' key with its value should be moved there. 'layerOptions' present different options that can be set on layers and change their behavior on the map. You can find out more about these settings in [docs](./doc/data-structures/config-files.md#Attributes-explained).
+
 ### Removed
 
 ### Fixed

--- a/api/src/dbSchemas/mapLayersSchema.js
+++ b/api/src/dbSchemas/mapLayersSchema.js
@@ -88,6 +88,7 @@ const MapLayerSchema = new mongoose.Schema({
   attributeTemplateName: String,
   featureId: String,
   metadata: MetadataSchema,
+  timeseries: Boolean,
   layerOptions: LayerOptionsSchema,
 });
 

--- a/api/src/dbSchemas/mapLayersSchema.js
+++ b/api/src/dbSchemas/mapLayersSchema.js
@@ -49,6 +49,15 @@ const LegendSchema = new mongoose.Schema(
   { _id: false },
 );
 
+const LayerOptionsSchema = new mongoose.Schema(
+  {
+    singleDisplay: Boolean,
+    maxResolution: Number,
+    timeseries: Boolean,
+  },
+  { _id: false },
+);
+
 const OneMapLayerData = new mongoose.Schema(
   {
     layerType: {
@@ -62,7 +71,6 @@ const OneMapLayerData = new mongoose.Schema(
     featureId: String,
     style: StyleSchema,
     legend: [LegendSchema],
-    maxResolution: Number,
   },
   { _id: false },
 );
@@ -80,7 +88,7 @@ const MapLayerSchema = new mongoose.Schema({
   attributeTemplateName: String,
   featureId: String,
   metadata: MetadataSchema,
-  timeseries: Boolean,
+  layerOptions: LayerOptionsSchema,
 });
 
 const MapLayer = mongoose.model('MapLayer', MapLayerSchema, 'mapLayers');
@@ -94,7 +102,6 @@ const SingleMapLayer = MapLayer.discriminator(
     },
     style: StyleSchema,
     legend: [LegendSchema],
-    maxResolution: Number,
   }),
 );
 

--- a/api/src/testUtils/testData/staticLayers.js
+++ b/api/src/testUtils/testData/staticLayers.js
@@ -222,7 +222,11 @@ const newMapLayers = [
     legend: {
       green: 'legend description',
     },
-    timeseries: true,
+    layerOptions: {
+      singleDisplay: false,
+      maxResolution: 1000,
+      timeseries: true,
+    }
   },
   {
     referenceId: 'refId1',

--- a/api/src/testUtils/testData/staticLayers.js
+++ b/api/src/testUtils/testData/staticLayers.js
@@ -55,6 +55,11 @@ const mapLayersInDb = [
       unit: 'n/a',
       dataRetrievalDescription: 'Data was randomly created.',
     },
+    layerOptions: {
+      singleDisplay: false,
+      maxResolution: 1000,
+      timeseries: true,
+    },
   },
   {
     referenceId: 'sampleMapLayer2',
@@ -177,6 +182,11 @@ const mapLayersInDb = [
       unit: 'n/a',
       dataRetrievalDescription: 'Data was randomly created.',
     },
+    layerOptions: {
+      singleDisplay: true,
+      maxResolution: 1000,
+      timeseries: false,
+    },
   },
   {
     referenceId: 'sampleMapLayer4',
@@ -221,11 +231,6 @@ const newMapLayers = [
     max: 5,
     legend: {
       green: 'legend description',
-    },
-    layerOptions: {
-      singleDisplay: false,
-      maxResolution: 1000,
-      timeseries: true,
     },
   },
   {

--- a/api/src/testUtils/testData/staticLayers.js
+++ b/api/src/testUtils/testData/staticLayers.js
@@ -226,7 +226,7 @@ const newMapLayers = [
       singleDisplay: false,
       maxResolution: 1000,
       timeseries: true,
-    }
+    },
   },
   {
     referenceId: 'refId1',

--- a/api/src/testUtils/testData/staticLayers.js
+++ b/api/src/testUtils/testData/staticLayers.js
@@ -55,11 +55,7 @@ const mapLayersInDb = [
       unit: 'n/a',
       dataRetrievalDescription: 'Data was randomly created.',
     },
-    layerOptions: {
-      singleDisplay: false,
-      maxResolution: 1000,
-      timeseries: true,
-    },
+    timeseries: false,
   },
   {
     referenceId: 'sampleMapLayer2',

--- a/api/src/tests/staticLayers.js
+++ b/api/src/tests/staticLayers.js
@@ -45,7 +45,7 @@ describe('GET /api/staticLayers', () => {
     expect(res.body[0].geoDataUrl).toEqual(layerGeoDataInDb.geoDataUrl);
     expect(res.body[0].format).toEqual(layerGeoDataInDb.format);
     expect(res.body[0].metadata.geoMetadata).toEqual(layerGeoDataInDb.metadata);
-    expect(res.body[0].layerOptions).toEqual(mapLayersInDb[0].layerOptions);
+    expect(res.body[0].timeseries).toEqual(mapLayersInDb[0].timeseries);
   });
   it('should return layer of type group with correct geodata links and format in sublayers', async () => {
     await LayerGeoData.create(layerGeoDataInDb);

--- a/api/src/tests/staticLayers.js
+++ b/api/src/tests/staticLayers.js
@@ -45,6 +45,7 @@ describe('GET /api/staticLayers', () => {
     expect(res.body[0].geoDataUrl).toEqual(layerGeoDataInDb.geoDataUrl);
     expect(res.body[0].format).toEqual(layerGeoDataInDb.format);
     expect(res.body[0].metadata.geoMetadata).toEqual(layerGeoDataInDb.metadata);
+    expect(res.body[0].layerOptions).toEqual(mapLayersInDb[0].layerOptions);
   });
   it('should return layer of type group with correct geodata links and format in sublayers', async () => {
     await LayerGeoData.create(layerGeoDataInDb);
@@ -54,6 +55,7 @@ describe('GET /api/staticLayers', () => {
     expect(res.status).toEqual(200);
     expect(res.body).toHaveLength(1);
     expect(res.body[0].referenceId).toEqual(mapLayersInDb[2].referenceId);
+    expect(res.body[0].layerOptions).toEqual(mapLayersInDb[2].layerOptions);
     res.body[0].layers.forEach((layer) => {
       expect(layer.geoDataUrl).toEqual(layerGeoDataInDb.geoDataUrl);
       expect(layer.format).toEqual(layerGeoDataInDb.format);

--- a/doc/data-structures/config-files.md
+++ b/doc/data-structures/config-files.md
@@ -132,7 +132,11 @@ This config file is one long array with settings for layers in map. As there are
 - **dataRetrievalDescription**:,
 - **dataCalculationDescription**:,
 
-**timeseries**: true or false, whether there are values from multiple dates in database and they should be displayed on frontend in timeline. If this value is false, the latest data are fetched,
+**layerOptions**: different options that can be set on layers and change their behavior on the map
+
+- **singleDisplay**: true or false, whether the region layer must be displayed alone or could be displayed with another layers
+- **maxResolution**: number, maximum resolution on which layer is shown
+- **timeseries**: true or false, whether there are values from multiple dates in database and they should be displayed on frontend in timeline. If this value is false, the latest data are fetched,
 
 #### Style object
 

--- a/doc/data-structures/in-database.md
+++ b/doc/data-structures/in-database.md
@@ -76,7 +76,6 @@ attributeDescription:
   noDataMessage: if value for the geographical unit is not available, this message will be displayed
   dateText: month for which the data applies, in this format: 'Reported period: {{dataDate}}'
 featureId: property name in geojson for geographical information
-timeseries: boolean value, whether timeseries data are available
 style:
   fillColor:
     type: type of color information, valid values: 'color', 'colormap'
@@ -106,6 +105,10 @@ metadata: information about the layer
   reliabilityScore: String
   dataRetrievalDescription: String
   dataCalculationDescription: String
+layerOptions:   
+  singleDisplay: boolean value, whether region layer should be displayed alone or can be displayed with other region layers
+  maxResolution: number, max resolution on which layer is shown
+  timeseries: boolean value, whether timeseries data are available
 ```
 
 or
@@ -128,7 +131,6 @@ layers: array with layers of structure from above
       noDataMessage: if value for the geographical unit not available, this message will be displayed
       dateText: month for which the data applies, in this format: 'Reported period: {{dataDate}}'
     featureId: property name in geojson for geographical information to match with data from database
-    timeseries: boolean value, whether timeseries data are available
     style:
       fillColor:
         type: type of color information, valid values: 'color', 'colormap'
@@ -158,6 +160,10 @@ metadata: information about the layer
   reliabilityScore: String
   dataRetrievalDescription: String
   dataCalculationDescription: String
+layerOptions:   
+  singleDisplay: boolean value, whether region layer should be displayed alone or can be displayed with other region layers
+  maxResolution: number, max resolution on which layer is shown
+  timeseries: boolean value, whether timeseries data are available  
 ```
 
 # Attributes

--- a/doc/tutorials/advanced/fetching-data-from-external-api.md
+++ b/doc/tutorials/advanced/fetching-data-from-external-api.md
@@ -8,7 +8,7 @@ As most of the team members are from Slovakia, we chose to fetch a sample data r
 
 ## Configuration
 
-URL loader configuration file and all necessary environment variables are set by default. You can just run the scripts as in following section. You can find further description of configuration file properties [here](../data-structures/config-files.md#url-loader-config).
+URL loader configuration file and all necessary environment variables are set by default. You can just run the scripts as in following section. You can find further description of configuration file properties [here](../../data-structures/config-files.md#url-loader-config).
 
 ./url-loader/sources/ExampleDailyUrls.yml
 
@@ -29,7 +29,7 @@ Before you start the service, please make sure, that Oscar application is runnin
 
 ## What can be seen in application
 
-For now you can check just that data are saved in raw-data Blob container in [Azure Storage Explorer](../development/development.md#setup-microsoft-azure-storage-explorer). With later introduction of Azure functions linked with URL loader service, you will be able to see data on the map.
+For now you can check just that data are saved in raw-data Blob container in [Azure Storage Explorer](../../development/development.md#setup-microsoft-azure-storage-explorer). With later introduction of Azure functions linked with URL loader service, you will be able to see data on the map.
 
 ## What's next
 

--- a/doc/tutorials/advanced/run-application-with-own-data.md
+++ b/doc/tutorials/advanced/run-application-with-own-data.md
@@ -11,10 +11,10 @@ Before start:
 Anytime set & run 'initial-data-load' service:
 - country name: ./runinitialload.sh `COUNTRY=Sample`
 - data types to be uploaded into the database: ./runinitialload.sh `UPLOAD_DATA_TYPES=mapLayers,attributes`
-- geodata: ./initial-data-load/data/{COUNTRY}/[geoData.yml](../data-structures/config-files.md#geodata.yml)
-- map layers: ./initial-data-load/data/{COUNTRY}/[mapLayers.yml](../data-structures/config-files.yml#maplayers.yml)
-- data in csv files: ./initial-data-load/data/{COUNTRY}/[attributes/](../data-structures/config-files#attributes)
-- config for csv files load: ./initial-data-load/data/{COUNTRY}/attributes/[index.js](../data-structures/config-files#index.js-for-attributes)
+- geodata: ./initial-data-load/data/{COUNTRY}/[geoData.yml](../../data-structures/config-files.md#geodata.yml)
+- map layers: ./initial-data-load/data/{COUNTRY}/[mapLayers.yml](../../data-structures/config-files.yml#maplayers.yml)
+- data in csv files: ./initial-data-load/data/{COUNTRY}/[attributes/](../../data-structures/config-files#attributes)
+- config for csv files load: ./initial-data-load/data/{COUNTRY}/attributes/[index.js](../../data-structures/config-files#index.js-for-attributes)
 
 ## Configuration before start
 Some of config files need to be created before running the app as they are part of the code or their values (environment variables) are included during build.     
@@ -54,7 +54,7 @@ For map view in the UI, you can set [x,y] coordinates and zoom level to focus th
 #### tabs setting
 In first version, there is only one Tab available.     
 **index** is order of the tab in the top menu. In future versions, you can create multiple tabs and order them. Order starts at 0 and it should be sequence of consecutive numbers.      
-**attributeIds** are names of attributes stored in database for specific graphs in tab. Each preset tab has own set of constants to be matched with data in database. Specific sets of attributeIds are described in [Dashboard Tabs](../UI/dashboard-tabs.md).     
+**attributeIds** are names of attributes stored in database for specific graphs in tab. Each preset tab has own set of constants to be matched with data in database. Specific sets of attributeIds are described in [Dashboard Tabs](../../UI/dashboard-tabs.md).     
      
 ## Configuration and data in data filling service
 `initial-data-load` service prepares structure in database and storage and fills them with data. This service can be run multiple times after the structure is set up.   
@@ -79,16 +79,16 @@ The geometrical objects in geojson (Features), can be easily linked with data in
 
 In order to correctly link all data, we recommend following this steps:      
 1. Get geojsons for all data with single coordinates per feature (one object on map), geometrical objects on map (shapes of buildings, lines of earthquake shakes, isochrones) and generic geojsons with various administrative levels. For introduction to the topic see [article at geodatasource.com](https://www.geodatasource.com/resources/tutorials/what-is-administrative-division/).    
-2. List all used geojsons in config file 'GeoData.yml' directly in COUNTRY folder. Structure of items in this config is described in detail in [Data Structures](../data-structures/config-files.md#geodata.yml).
-3. Create list of map layers in config file 'MapLayers.yml'. Before we provide you with link to structure of items as above, keep in mind, that for 'attribute', you need either to take name of property in Feature from geojson or create your own 'attribute' which will be used for data in attributes structure also. With this in mind, let's create the layers with [following structure](../data-structures/config-files.md#maplayers.yml).
+2. List all used geojsons in config file 'GeoData.yml' directly in COUNTRY folder. Structure of items in this config is described in detail in [Data Structures](../../data-structures/config-files.md#geodata.yml).
+3. Create list of map layers in config file 'MapLayers.yml'. Before we provide you with link to structure of items as above, keep in mind, that for 'attribute', you need either to take name of property in Feature from geojson or create your own 'attribute' which will be used for data in attributes structure also. With this in mind, let's create the layers with [following structure](../../data-structures/config-files.md#maplayers.yml).
   
-4. In this step, we can finally make first run of initial data load service with our data. Check [Run application](../getting-started/run-application.md) tutorial for details on how to start application locally.    
+4. In this step, we can finally make first run of initial data load service with our data. Check [Run application](../../getting-started/run-application.md) tutorial for details on how to start application locally.    
 
 If everything went correctly, after you start application, run the service with correct environment variables and refresh web page in browser. The layers should be in [menu on frontend](../UI/map.md). For all layers with values only in geojsons, the values should be already there and the rest should have grey areas (or colour set for missing values), that we later get from attributes collection from the database.        
 5. Now is time to move to attributes to fix the empty layers and fill dashboard with data.      
     
 ### Attributes
-This functionality is run, if environment variable `UPLOAD_DATA_TYPES=layerAttributes` is set in `./runinitialload.sh` script and stores data for specific point (or interval) in space and time in 'attributes' collection. These values are stored in ["attribute" format](../data-structures/in-database.md#attributes):
+This functionality is run, if environment variable `UPLOAD_DATA_TYPES=layerAttributes` is set in `./runinitialload.sh` script and stores data for specific point (or interval) in space and time in 'attributes' collection. These values are stored in ["attribute" format](../../data-structures/in-database.md#attributes):
       
 #### How to get this data into database   
 Short answer is as you wish. As far as you keep the structure correct, the application can process them from database. As of now, we provide one way to store the data, but in following version, multiple ways will be presented and this tutorial will be automatically updated.       
@@ -108,4 +108,4 @@ One csv file can contain more data for the same AdminArea list. Each will be sto
 Although 'initial-data-load' has the word _initial_ in name, it can be run multiple times on already running application for data update.      
 All that is needed is replace the data in .csv files with current data, update date in index.js file and run the service again with environment variable `UPLOAD_DATA_TYPES=attributes`. 
 If the data is always uploaded for today or yesterday, this date can be set in the index.js as value relative to now (date and time in moment of running the service) and there will be only one place, where data need to be updated.    
-The data will be stored under the new date and if the date is later than the previous one, this data will be automatically used. This approach also produces sets of data for different dates that will be loaded as timeline for layers with key [timeseries: true](../UI/map.md) set in MapLayers.yml.
+The data will be stored under the new date and if the date is later than the previous one, this data will be automatically used. This approach also produces sets of data for different dates that will be loaded as timeline for layers with key [layerOptions: timeseries: true](../../UI/map.md) set in MapLayers.yml.

--- a/doc/tutorials/advanced/run-application-with-own-data.md
+++ b/doc/tutorials/advanced/run-application-with-own-data.md
@@ -12,9 +12,9 @@ Anytime set & run 'initial-data-load' service:
 - country name: ./runinitialload.sh `COUNTRY=Sample`
 - data types to be uploaded into the database: ./runinitialload.sh `UPLOAD_DATA_TYPES=mapLayers,attributes`
 - geodata: ./initial-data-load/data/{COUNTRY}/[geoData.yml](../../data-structures/config-files.md#geodata.yml)
-- map layers: ./initial-data-load/data/{COUNTRY}/[mapLayers.yml](../../data-structures/config-files.yml#maplayers.yml)
-- data in csv files: ./initial-data-load/data/{COUNTRY}/[attributes/](../../data-structures/config-files#attributes)
-- config for csv files load: ./initial-data-load/data/{COUNTRY}/attributes/[index.js](../../data-structures/config-files#index.js-for-attributes)
+- map layers: ./initial-data-load/data/{COUNTRY}/[mapLayers.yml](../../data-structures/config-files.md#maplayers.yml)
+- data in csv files: ./initial-data-load/data/{COUNTRY}/[attributes/](../../data-structures/config-files.md#attributes)
+- config for csv files load: ./initial-data-load/data/{COUNTRY}/attributes/[index.js](../../data-structures/config-files.md#index.js-for-attributes)
 
 ## Configuration before start
 Some of config files need to be created before running the app as they are part of the code or their values (environment variables) are included during build.     

--- a/doc/tutorials/advanced/run-application-with-sample-data.md
+++ b/doc/tutorials/advanced/run-application-with-sample-data.md
@@ -14,17 +14,17 @@ The data provided for dashboard graph and map layers is also made up by us and d
 
 All necessary configuration files and environment variables are set by default. You can just run the scripts as in following section.
 
-First configuration is the setup of [dashboard](../UI/dashboard-tabs.md) in ./api/data/config/config.yml. In this location we provided configuration file with map coordinates to focus on Slovakia and correct zoom level to see the whole country on screen. Second part of the file tells the dashboard graphs where in the api the data can be found.
+First configuration is the setup of [dashboard](../../UI/dashboard-tabs.md) in ./api/data/config/config.yml. In this location we provided configuration file with map coordinates to focus on Slovakia and correct zoom level to see the whole country on screen. Second part of the file tells the dashboard graphs where in the api the data can be found.
 
 Sample data themselves are stored in ./initial-data-load/data/Sample folder. Here we can find geoData.yml and geoData folder with geojson files for the geo-location part of information. First file has all the regions (admin1 level) for the country and second one stores locations of hospitals (for our purpose).
 
-Second part of the data is in mapLayers.yml, file responsible for the actual layers in menu in [map view](../UI/map.md).
+Second part of the data is in mapLayers.yml, file responsible for the actual layers in menu in [map view](../../UI/map.md).
 
 Attributes folder has config file in javascript to easily add current dates in the sample data, so all the functionality of dashboard will work without further update to the data. The data itself is stored in cvs files in this folder.
 
 ## Run Oscar application
 
-If this is your first attempt to run the application, please consult [Getting started](../getting-started/run-application.md) first. There are some necessary prerequisities.
+If this is your first attempt to run the application, please consult [Getting started](../../getting-started/run-application.md) first. There are some necessary prerequisities.
 Now you are set and ready to run the scripts. As all files are already in place, all you need is run these two scripts:
 
 `./start.sh` will start the api, frontend and database. Once you can see the frontend, you can go to next script (don't worry about the empty menu and dashboard, it will be filled in next step).
@@ -33,8 +33,8 @@ Now you are set and ready to run the scripts. As all files are already in place,
 
 ## What can be seen in application
 
-The [map view](../UI/map.md) is focused on Slovakia and in the layers menu, you can select from these layers:
+The [map view](../../UI/map.md) is focused on Slovakia and in the layers menu, you can select from these layers:
 
-![layers menu with sample layers |50%](./sampleMapLayersMenu.png)
+![layers menu with sample layers |50%](../sampleMapLayersMenu.png)
 
-Also all graphs have data, exactly as in [dashboard tabs description page](../UI/dashboard-tabs.md).
+Also all graphs have data, exactly as in [dashboard tabs description page](../../UI/dashboard-tabs.md).

--- a/frontend/src/ol/staticLayers/layerTypes/combined.js
+++ b/frontend/src/ol/staticLayers/layerTypes/combined.js
@@ -16,6 +16,8 @@ const combinedLayer = (layerData, handleIsLoading) => {
     style: combinedStyleFactory(layerData.attribute, layerData.style),
     legend: layerData.legend,
     minZoom: 11,
+    layerOptions: layerData.layerOptions,
+    maxResolution: layerData.layerOptions.maxResolution || layerData.maxResolution,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/combined.js
+++ b/frontend/src/ol/staticLayers/layerTypes/combined.js
@@ -17,7 +17,7 @@ const combinedLayer = (layerData, handleIsLoading) => {
     legend: layerData.legend,
     minZoom: 11,
     layerOptions: layerData.layerOptions,
-    maxResolution: layerData.layerOptions.maxResolution || layerData.maxResolution,
+    maxResolution: (layerData.layerOptions && layerData.layerOptions.maxResolution) || layerData.maxResolution,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/geometry.js
+++ b/frontend/src/ol/staticLayers/layerTypes/geometry.js
@@ -40,6 +40,8 @@ const geometryLayer = (layerData, handleIsLoading) => {
     zIndex: 1,
     style: geometryStyleFactory(layerData.attribute, layerData.style),
     legend: layerData.legend,
+    layerOptions: layerData.layerOptions,
+    maxResolution: layerData.layerOptions.maxResolution || layerData.maxResolution,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/geometry.js
+++ b/frontend/src/ol/staticLayers/layerTypes/geometry.js
@@ -41,7 +41,7 @@ const geometryLayer = (layerData, handleIsLoading) => {
     style: geometryStyleFactory(layerData.attribute, layerData.style),
     legend: layerData.legend,
     layerOptions: layerData.layerOptions,
-    maxResolution: layerData.layerOptions.maxResolution || layerData.maxResolution,
+    maxResolution: (layerData.layerOptions && layerData.layerOptions.maxResolution) || layerData.maxResolution,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/group.js
+++ b/frontend/src/ol/staticLayers/layerTypes/group.js
@@ -9,7 +9,11 @@ const groupLayer = (layerData, handleIsLoading) => {
     legend: layerData.legend,
     layers: layerData.layers.map((layer) =>
       staticLayerGenerator(
-        { ...layer, visible: true, maxResolution: layerData.layerOptions.maxResolution },
+        {
+          ...layer,
+          visible: true,
+          maxResolution: (layerData.layerOptions && layerData.layerOptions.maxResolution) || layerData.maxResolution,
+        },
         handleIsLoading,
       ),
     ),

--- a/frontend/src/ol/staticLayers/layerTypes/group.js
+++ b/frontend/src/ol/staticLayers/layerTypes/group.js
@@ -8,7 +8,7 @@ const groupLayer = (layerData, handleIsLoading) => {
     type: layerData.layerType,
     legend: layerData.legend,
     layers: layerData.layers.map((layer) => staticLayerGenerator({ ...layer, visible: true }, handleIsLoading)),
-    timeseries: layerData.timeseries,
+    layerOptions: layerData.layerOptions,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/group.js
+++ b/frontend/src/ol/staticLayers/layerTypes/group.js
@@ -7,7 +7,12 @@ const groupLayer = (layerData, handleIsLoading) => {
     title: layerData.title,
     type: layerData.layerType,
     legend: layerData.legend,
-    layers: layerData.layers.map((layer) => staticLayerGenerator({ ...layer, visible: true }, handleIsLoading)),
+    layers: layerData.layers.map((layer) =>
+      staticLayerGenerator(
+        { ...layer, visible: true, maxResolution: layerData.layerOptions.maxResolution },
+        handleIsLoading,
+      ),
+    ),
     layerOptions: layerData.layerOptions,
   });
   newLayer.selectable = true;

--- a/frontend/src/ol/staticLayers/layerTypes/points.js
+++ b/frontend/src/ol/staticLayers/layerTypes/points.js
@@ -27,7 +27,7 @@ const pointsLayer = (layerData, handleIsLoading) => {
     legend: layerData.legend,
     zIndex: 2,
     layerOptions: layerData.layerOptions,
-    maxResolution: layerData.layerOptions.maxResolution || layerData.maxResolution,
+    maxResolution: (layerData.layerOptions && layerData.layerOptions.maxResolution) || layerData.maxResolution,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/points.js
+++ b/frontend/src/ol/staticLayers/layerTypes/points.js
@@ -26,7 +26,7 @@ const pointsLayer = (layerData, handleIsLoading) => {
     style: pointStyleFactory(layerData.attribute, layerData.style),
     legend: layerData.legend,
     zIndex: 2,
-    timeseries: layerData.timeseries,
+    layerOptions: layerData.layerOptions,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/points.js
+++ b/frontend/src/ol/staticLayers/layerTypes/points.js
@@ -27,6 +27,7 @@ const pointsLayer = (layerData, handleIsLoading) => {
     legend: layerData.legend,
     zIndex: 2,
     layerOptions: layerData.layerOptions,
+    maxResolution: layerData.layerOptions.maxResolution || layerData.maxResolution,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/regions.js
+++ b/frontend/src/ol/staticLayers/layerTypes/regions.js
@@ -17,7 +17,7 @@ const regionsLayer = (layerData, handleIsLoading) => {
     legend: layerData.legend,
     zIndex: 0,
     layerOptions: layerData.layerOptions,
-    maxResolution: layerData.layerOptions.maxResolution || layerData.maxResolution,
+    maxResolution: (layerData.layerOptions && layerData.layerOptions.maxResolution) || layerData.maxResolution,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/regions.js
+++ b/frontend/src/ol/staticLayers/layerTypes/regions.js
@@ -16,7 +16,7 @@ const regionsLayer = (layerData, handleIsLoading) => {
     style: regionStyleFactory(layerData.attribute, layerData.style),
     legend: layerData.legend,
     zIndex: 0,
-    timeseries: layerData.timeseries,
+    layerOptions: layerData.layerOptions,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/layerTypes/regions.js
+++ b/frontend/src/ol/staticLayers/layerTypes/regions.js
@@ -17,6 +17,7 @@ const regionsLayer = (layerData, handleIsLoading) => {
     legend: layerData.legend,
     zIndex: 0,
     layerOptions: layerData.layerOptions,
+    maxResolution: layerData.layerOptions.maxResolution || layerData.maxResolution,
   });
   newLayer.selectable = true;
   if (layerData.visible) {

--- a/frontend/src/ol/staticLayers/loaders/vectorSourceLoader.js
+++ b/frontend/src/ol/staticLayers/loaders/vectorSourceLoader.js
@@ -18,7 +18,7 @@ const vectorSourceLoader = (layerData, handleIsLoading, title, type) => {
             let attributes = [];
 
             if (layerData.attribute) {
-              if (vectorSource.get('sliderDate') && layerData.timeseries) {
+              if (vectorSource.get('sliderDate') && layerData.layerOptions.timeseries) {
                 const searchParams = new URLSearchParams();
                 searchParams.append('attributeId', layerData.attribute);
                 searchParams.append('dateStart', vectorSource.get('sliderDate'));

--- a/frontend/src/ol/staticLayers/staticLayerGenerator.js
+++ b/frontend/src/ol/staticLayers/staticLayerGenerator.js
@@ -7,21 +7,27 @@ import combinedLayer from './layerTypes/combined';
 import groupLayer from './layerTypes/group';
 
 const staticLayerGenerator = (layerData, handleIsLoading) => {
+  let layerOptions;
+  if (layerData.timeseries !== null) {
+    layerOptions = { timeseries: layerData.timeseries };
+  } else {
+    layerOptions = layerData.layerOptions;
+  }
   switch (layerData.layerType) {
     case staticLayersTypes.REGIONS: {
-      return regionsLayer(layerData, handleIsLoading);
+      return regionsLayer({ ...layerData, layerOptions }, handleIsLoading);
     }
     case staticLayersTypes.POINTS: {
-      return pointsLayer(layerData, handleIsLoading);
+      return pointsLayer({ ...layerData, layerOptions }, handleIsLoading);
     }
     case staticLayersTypes.GEOMETRY: {
-      return geometryLayer(layerData, handleIsLoading);
+      return geometryLayer({ ...layerData, layerOptions }, handleIsLoading);
     }
     case staticLayersTypes.GROUP: {
-      return groupLayer(layerData, handleIsLoading);
+      return groupLayer({ ...layerData, layerOptions }, handleIsLoading);
     }
     case staticLayersTypes.COMBINED: {
-      return combinedLayer(layerData, handleIsLoading);
+      return combinedLayer({ ...layerData, layerOptions }, handleIsLoading);
     }
     // eslint-disable-next-line no-empty
     default: {

--- a/frontend/src/ol/staticLayers/styles.js
+++ b/frontend/src/ol/staticLayers/styles.js
@@ -79,7 +79,7 @@ export const regionStyleFactory = (attribute, layerStyle) => {
     let fillColor;
     const value = feature.get(attribute);
     if (isNotDefinedIncl0(value)) {
-      fillColor = layerStyle.missingValueColor || 'grey';
+      fillColor = layerStyle.missingValueColor || 'rgb(128,128,128, 0.5)';
     } else if (layerStyle.fillColor) {
       fillColor = getColorFromLayerStyle(value, layerStyle.fillColor, layerStyle.min, layerStyle.max);
     } else if (layerStyle.fillColors) {

--- a/frontend/src/screens/Map/PublicMap.js
+++ b/frontend/src/screens/Map/PublicMap.js
@@ -160,6 +160,7 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
         const timeseriesLayerIndex = staticLayers.findIndex(
           (layer) =>
             layer.get('title') !== title &&
+            layer.get('layerOptions') &&
             !layer.get('layerOptions').singleDisplay &&
             layer.get('layerOptions').timeseries &&
             layer.getVisible(),
@@ -179,10 +180,12 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
         // layer is not selected, selecting
         // deselect the rest of regions layers, if regions layer with singleDisplay true is selected
         if (modifiedLayer.get('type') === staticLayersTypes.REGIONS) {
-          if (modifiedLayer.get('layerOptions').singleDisplay) {
+          const MLlayerOptions = modifiedLayer.get('layerOptions') || {};
+          if (MLlayerOptions.singleDisplay) {
             staticLayers.forEach((layer) => {
               if (layer.get('type') === staticLayersTypes.REGIONS && layer.get('title') !== title) {
-                if (layer.get('layerOptions').timeseries && layer.getVisible()) {
+                const layerLayerOptions = layer.get('layerOptions') || {};
+                if (layerLayerOptions.timeseries && layer.getVisible()) {
                   setTimeSeriesSlider(false);
                 }
                 layer.setVisible(false);
@@ -194,6 +197,7 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
               (layer) =>
                 layer.get('type') === staticLayersTypes.REGIONS &&
                 layer.get('title') !== title &&
+                layer.get('layerOptions') &&
                 layer.get('layerOptions').singleDisplay &&
                 layer.getVisible(),
             );
@@ -208,7 +212,8 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
         }
 
         // select correct layer and timeline, if timeseries data available
-        if (modifiedLayer.get('layerOptions').timeseries) {
+        const layerOptions = modifiedLayer.get('layerOptions');
+        if ((layerOptions && layerOptions.timeseries) || modifiedLayer.timeseries) {
           const availableDates = await getAvailableDates(modifiedLayer.get('attribute'));
           if (availableDates && availableDates.length > 1) {
             showTimeseriesSlider(availableDates, modifiedLayer);

--- a/frontend/src/screens/Map/PublicMap.js
+++ b/frontend/src/screens/Map/PublicMap.js
@@ -172,7 +172,7 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
             showTimeseriesSlider(availableDates, timeseriesLayer);
           }
           // for last layer with time series that is being deselected, hide slider and clear modifiedLayer state
-        } else if (modifiedLayer.get('layerOptions').timeseries) {
+        } else if (modifiedLayer.get('layerOptions') && modifiedLayer.get('layerOptions').timeseries) {
           setTimeSeriesSlider(false);
           setModifiedLayer(null);
         }

--- a/frontend/src/screens/Map/PublicMap.js
+++ b/frontend/src/screens/Map/PublicMap.js
@@ -148,17 +148,20 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
         // layer is selected, deselecting
         modifiedLayer.setVisible(false);
         // for layer with time series also hide slider and clear modifiedLayer state
-        if (modifiedLayer.get('timeseries')) {
+        if (modifiedLayer.get('layerOptions').timeseries) {
           setTimeSeriesSlider(false);
           setModifiedLayer(null);
         }
       } else {
         // layer is not selected, selecting
         // deselect the rest of regions layers, if regions layer selected
-        if (modifiedLayer.get('type') === staticLayersTypes.REGIONS) {
+        if (
+          modifiedLayer.get('layerOptions').singleDisplay &&
+          modifiedLayer.get('type') === staticLayersTypes.REGIONS
+        ) {
           staticLayers.forEach((layer) => {
             if (layer.get('type') === staticLayersTypes.REGIONS && layer.get('title') !== title) {
-              if (layer.get('timeseries') && layer.getVisible()) {
+              if (layer.get('layerOptions').timeseries && layer.getVisible()) {
                 setTimeSeriesSlider(false);
               }
               layer.setVisible(false);
@@ -166,7 +169,7 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
           });
         }
         // select correct layer and timeline, if timeseries data available
-        if (modifiedLayer.get('timeseries')) {
+        if (modifiedLayer.get('layerOptions').timeseries) {
           const availableDates = await getAvailableDates(modifiedLayer.get('attribute'));
           if (availableDates && availableDates.length > 1) {
             setAvailableDates(availableDates);

--- a/frontend/src/screens/Map/PublicMap.js
+++ b/frontend/src/screens/Map/PublicMap.js
@@ -236,6 +236,11 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
     if (!mapPosition) {
       return;
     }
+    if (mapPosition) {
+      if (Number.isNaN(parseFloat(mapPosition.center[0]))) {
+        return;
+      }
+    }
     map.getView().setCenter(mapPosition.center);
     map.getView().setZoom(mapPosition.zoom);
     const hash = `#map=${map.getView().getZoom()}/${Math.round(map.getView().getCenter()[0] * 100) / 100}/${

--- a/frontend/src/screens/Map/PublicMap.js
+++ b/frontend/src/screens/Map/PublicMap.js
@@ -178,9 +178,9 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
         }
       } else {
         // layer is not selected, selecting
-        // deselect the rest of regions layers, if regions layer with singleDisplay true is selected
         if (modifiedLayer.get('type') === staticLayersTypes.REGIONS) {
           const MLlayerOptions = modifiedLayer.get('layerOptions') || {};
+          // deselect the rest of regions layers, if regions layer with singleDisplay true is selected
           if (MLlayerOptions.singleDisplay) {
             staticLayers.forEach((layer) => {
               if (layer.get('type') === staticLayersTypes.REGIONS && layer.get('title') !== title) {
@@ -192,7 +192,7 @@ const PublicMap = ({ isLoading, handleIsLoading }) => {
               }
             });
           } else {
-            // deselect regions layer, which have singleDisplay true, if regions layer with singleDisplay false is selected
+            // deselect regions layer, which has singleDisplay true, if regions layer with singleDisplay false is selected
             const singleDisplayLayerIndex = staticLayers.findIndex(
               (layer) =>
                 layer.get('type') === staticLayersTypes.REGIONS &&

--- a/frontend/src/screens/Map/TimeSeriesSlider.js
+++ b/frontend/src/screens/Map/TimeSeriesSlider.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Slider from '@material-ui/core/Slider';
 import { withStyles } from '@material-ui/core/styles';
 import { Tooltip } from '@material-ui/core';
@@ -123,6 +123,10 @@ const TimeSeriesSlider = ({ availableDates, modifiedLayer }) => {
   const maxValue = marks[marks.length - 1].value;
 
   const [currentValue, setCurrentValue] = useState(undefined);
+
+  useEffect(() => {
+    setCurrentValue(undefined);
+  }, [modifiedLayer]);
 
   const valueLabelFormat = (value) => {
     if (!currentValue) {

--- a/initial-data-load/data/Sample/MapLayers.yml
+++ b/initial-data-load/data/Sample/MapLayers.yml
@@ -14,7 +14,9 @@
   legend:
     - type: "colormap"
       color: "blue"
-  timeseries: false
+  layerOptions: 
+    singleDisplay: false    
+    timeseries: false
 
 - referenceId: "dailyCasesPerAdmin1"
   geoReferenceId: "slovakiaRegions"
@@ -45,7 +47,9 @@
     updateFrequency: "never"
     unit: "n/a"
     dataRetrievalDescription: "Data was randomly created."
-  timeseries: true
+  layerOptions: 
+    singleDisplay: false    
+    timeseries: true
 
 - referenceId: "7daysIncidenceRatePerProvince"
   geoReferenceId: "slovakiaRegions"
@@ -76,8 +80,9 @@
     updateFrequency: "never"
     unit: "n/a"
     dataRetrievalDescription: "Data was randomly created."
-
-  timeseries: false
+  layerOptions: 
+    singleDisplay: false   
+    timeseries: false
 
 - referenceId: "hospitalHealthSites"
   geoReferenceId: "slovakiaHospitals"
@@ -99,4 +104,6 @@
     - type: "color"
       color: "rgba(0, 80, 0, 1)"
       description: "Hospital"
-  timeseries: false
+  layerOptions: 
+    singleDisplay: false   
+    timeseries: false

--- a/initial-data-load/src/mapLayers/mapLayersSchema.js
+++ b/initial-data-load/src/mapLayers/mapLayersSchema.js
@@ -88,6 +88,7 @@ const MapLayerSchema = new mongoose.Schema({
   attributeTemplateName: String,
   featureId: String,
   metadata: MetadataSchema,
+  timeseries: Boolean,
   layerOptions: LayerOptionsSchema,
 });
 

--- a/initial-data-load/src/mapLayers/mapLayersSchema.js
+++ b/initial-data-load/src/mapLayers/mapLayersSchema.js
@@ -49,6 +49,15 @@ const LegendSchema = new mongoose.Schema(
   { _id: false },
 );
 
+const LayerOptionsSchema = new mongoose.Schema(
+  {
+    singleDisplay: Boolean,
+    maxResolution: Number,
+    timeseries: Boolean,
+  },
+  { _id: false },
+);
+
 const OneMapLayerData = new mongoose.Schema(
   {
     layerType: {
@@ -62,7 +71,6 @@ const OneMapLayerData = new mongoose.Schema(
     featureId: String,
     style: StyleSchema,
     legend: [LegendSchema],
-    maxResolution: Number,
   },
   { _id: false },
 );
@@ -80,7 +88,7 @@ const MapLayerSchema = new mongoose.Schema({
   attributeTemplateName: String,
   featureId: String,
   metadata: MetadataSchema,
-  timeseries: Boolean,
+  layerOptions: LayerOptionsSchema,
 });
 
 const MapLayer = mongoose.model('MapLayer', MapLayerSchema, 'mapLayers');
@@ -94,7 +102,6 @@ const SingleMapLayer = MapLayer.discriminator(
     },
     style: StyleSchema,
     legend: [LegendSchema],
-    maxResolution: Number,
   }),
 );
 

--- a/initial-data-load/src/mapLayers/mapLayersUpload.js
+++ b/initial-data-load/src/mapLayers/mapLayersUpload.js
@@ -30,7 +30,7 @@ const addMapLayer = async (data) => {
       featureId: data.featureId,
       metadata: data.metadata,
       layers: updatedLayers,
-      timeseries: data.timeseries,
+      layerOptions: data.layerOptions,
     };
   }
   if (data.geoReferenceId) {
@@ -53,7 +53,7 @@ const addMapLayer = async (data) => {
     metadata: data.metadata,
     style: data.style,
     legend: data.legend,
-    timeseries: data.timeseries,
+    layerOptions: data.layerOptions,
   };
 };
 

--- a/initial-data-load/src/mapLayers/mapLayersUpload.js
+++ b/initial-data-load/src/mapLayers/mapLayersUpload.js
@@ -6,6 +6,9 @@ const logger = require('../config/winston');
 const { getOneLayerGeoData, saveMapLayers } = require('./db');
 
 const addMapLayer = async (data) => {
+  if (data.timeseries !== undefined) {
+    logger.info(`DeprecationWarning: 'timeseries' key on the top level is deprecated. Move 'timeseries' key in 'layerOptions' key in ${data.referenceId} layer in mapLayers config.`);
+  }
   if (data.layerType === 'group') {
     const updatedLayers = await Promise.all([
       ...data.layers.map(async (layer) => {
@@ -30,6 +33,7 @@ const addMapLayer = async (data) => {
       featureId: data.featureId,
       metadata: data.metadata,
       layers: updatedLayers,
+      timeseries: data.timeseries,
       layerOptions: data.layerOptions,
     };
   }
@@ -53,6 +57,7 @@ const addMapLayer = async (data) => {
     metadata: data.metadata,
     style: data.style,
     legend: data.legend,
+    timeseries: data.timeseries,
     layerOptions: data.layerOptions,
   };
 };

--- a/initial-data-load/src/mapLayers/mapLayersUpload.js
+++ b/initial-data-load/src/mapLayers/mapLayersUpload.js
@@ -7,7 +7,9 @@ const { getOneLayerGeoData, saveMapLayers } = require('./db');
 
 const addMapLayer = async (data) => {
   if (data.timeseries !== undefined) {
-    logger.info(`DeprecationWarning: 'timeseries' key on the top level is deprecated. Move 'timeseries' key in 'layerOptions' key in ${data.referenceId} layer in mapLayers config.`);
+    logger.info(
+      `DeprecationWarning: 'timeseries' key on the top level is deprecated. Move 'timeseries' key in 'layerOptions' key in ${data.referenceId} layer in mapLayers config.`,
+    );
   }
   if (data.layerType === 'group') {
     const updatedLayers = await Promise.all([


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!--- Provide a general summary of the issue in the Title above -->

## Description
<!--- Describe your changes in detail -->
Show multiple region layers. Create layerOptions in mapLayers config.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
TEST singleLayer: true with 2 timeseries layers behavior:
- upload this these files in to initial-data-load/data/Sample/attributes/daily_cases_test folder
[Daily_Covid19_cases1.csv](https://github.com/openkfw/Oscar/files/7800858/Daily_Covid19_cases1.csv)
[Daily_Covid19_cases2.csv](https://github.com/openkfw/Oscar/files/7800859/Daily_Covid19_cases2.csv)
[Daily_Covid19_cases3.csv](https://github.com/openkfw/Oscar/files/7800860/Daily_Covid19_cases3.csv)
- add these lines to initial-data-load/data/Sample/attributes/index.js

```-  {
    referenceId: 'DailyCovid19Cases',
    date: new Date(now - 1 * oneDay).toISOString(),
    csvFileName: 'daily_cases_test/Daily_Covid19_cases1.csv',
  },
  {
    referenceId: 'DailyCovid19Cases',
    date: new Date(now - 2 * oneDay).toISOString(),
    csvFileName: 'daily_cases_test/Daily_Covid19_cases2.csv',
  },
  {
    referenceId: 'DailyCovid19Cases',
    date: new Date(now - 3 * oneDay).toISOString(),
    csvFileName: 'daily_cases_test/Daily_Covid19_cases3.csv',
  },
```

- add test layer to MapLayers.yml

```- referenceId: "dailyCases"
  geoReferenceId: "slovakiaRegions"
  layerType: "regions"
  category: "Baseline data"
  title: "Daily Covid-19"
  attribute: "Daily Covid19 Cases"
  attributeDescription:
    descriptionText: "COVID-19 New Cases: {{Daily Covid19 Cases}}"
    featureText: "{{featureId}} kraj"
  featureId: "name"
  style:
    fillColor:
      type: "colormap"
      value: "green"
    min: 0
    max: 100
    strokeColor:
      type: "color"
      value: "rgba(255,255,255,0.2)"
  legend:
    - type: "colormap"
      color: "green"
      min: 0
      max: 100
  metadata:
    description: "Sample data created just for this purpose. Do not represent the reality in any time."
    updateFrequency: "never"
    unit: "n/a"
    dataRetrievalDescription: "Data was randomly created."
  layerOptions: 
    singleDisplay: false   
    timeseries: true
```
Leave singleDisplay false for both timeseries layers to check functionality with more sliders shown on the map. Change singleDisplay to true in other layers for checking singleDisplay functionality. Add maxResolution: 1000 to any of the layers to check if it works.

Run ./start.sh, ./runinitialload.sh with COUNTRY=Sample. Check layers on the map.
Now you have 2 timeseries layers for testing purposes, one in Baseline data and one in Covid-19. You can add one more for testing purposes.
- check points in https://github.com/openkfw/Oscar/issues/89
- check new functionality in publicMap.js and if comments are understandable
- check layer without values, that it is transparent gray
- run tests in api
- check release notes
- check documentation and schema changes
- slider behavior is the same for all the layer types, singleDisplay behavior is added just for regions layers, other layer types will act like before, so they will appear together with regions layers, singleDisplay flag in them won't have any effect
- this task doesn't solve layer ordering, when 2 region layers overlay each other, the color doesn't corespond to legend, because the colors are mixed together, we should use z-index later to fix this.
- check group layer

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document.
- [X] I have checked to ensure that there aren't other open [Pull Requests](../../../pulls) for the same update/change.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
