### PR TITLE
Add tile layer type and format to geodata schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - new color style type 'intervals' [117](https://github.com/openkfw/Oscar/pull/120)
-- 'metadata.attributions' key in ./initial-data-load/data/{country}/GeoData.yml configuration file as a substite for 'tileAttributions' key on the top level that is now deprecated. You can find out more about these settings in [docs](./doc/data-structures/config-files.md#geoData.yml). [#146](https://github.com/openkfw/Oscar/pull/146/files)
-- 'metadata.attributions' key in ./initial-data-load/data/{country}/MapLayers.yml configuration file
+- 'metadata.attributions' key in ./initial-data-load/data/{dataset}/GeoData.yml configuration file as a substite for 'tileAttributions' key on the top level that is now deprecated. You can find out more about these settings in [docs](./doc/data-structures/config-files.md#geoData.yml). [#146](https://github.com/openkfw/Oscar/pull/146/files)
+- 'metadata.attributions' key in ./initial-data-load/data/{dataset}/MapLayers.yml configuration file
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - new color style type 'intervals' [117](https://github.com/openkfw/Oscar/pull/120)
+- 'metadata.attributions' key in ./initial-data-load/data/{country}/GeoData.yml configuration file as a substite for 'tileAttributions' key on the top level that is now deprecated. You can find out more about these settings in [docs](./doc/data-structures/config-files.md#geoData.yml). [#146](https://github.com/openkfw/Oscar/pull/146/files)
+- 'metadata.attributions' key in ./initial-data-load/data/{country}/MapLayers.yml configuration file
 
 ### Changed
 
@@ -18,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - route '/api/staticLayers', use '/api/dataLayers' [111]()
 - 'COUNTRY' environment variable for initial-data-load, use 'DATASET' instead
-- 'tileDataUrl' and 'tileAttributions' keys on the top level in ./initial-data-load/data/{country}/GeoData.yml configuration file are now deprecated. Use 'apiUrl' key instead of 'tileDataUrl' key and 'metadata.description' key instead of 'tileAttributions' key. You can find out more about these settings in [docs](./doc/data-structures/config-files.md#geoData.yml).
+- 'tileDataUrl' and 'tileAttributions' keys on the top level in ./initial-data-load/data/{country}/GeoData.yml configuration file. Use 'apiUrl' key instead of 'tileDataUrl' key and 'metadata.attributions' key instead of 'tileAttributions' key. You can find out more about these settings in [docs](./doc/data-structures/config-files.md#geoData.yml). [#146](https://github.com/openkfw/Oscar/pull/146/files)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Deprecated
+- 'tileDataUrl' and 'tileAttributions' keys on the top level in ./initial-data-load/data/{country}/GeoData.yml configuration file. Use 'apiUrl' key instead of 'tileDataUrl' key and 'metadata.attributions' key instead of 'tileAttributions' key. You can find out more about these settings in [docs](./doc/data-structures/config-files.md#geoData.yml). [#146](https://github.com/openkfw/Oscar/pull/146/files)
 
 ### Removed
 
@@ -45,7 +46,6 @@ Introducing option to use postgresql as database, with the exception of function
 
 - route '/api/staticLayers', use '/api/dataLayers' [#111](https://github.com/openkfw/Oscar/issues/111)
 - 'COUNTRY' environment variable for initial-data-load, use 'DATASET' instead
-- 'tileDataUrl' and 'tileAttributions' keys on the top level in ./initial-data-load/data/{country}/GeoData.yml configuration file. Use 'apiUrl' key instead of 'tileDataUrl' key and 'metadata.attributions' key instead of 'tileAttributions' key. You can find out more about these settings in [docs](./doc/data-structures/config-files.md#geoData.yml). [#146](https://github.com/openkfw/Oscar/pull/146/files)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - route '/api/staticLayers', use '/api/dataLayers' [111]()
 - 'COUNTRY' environment variable for initial-data-load, use 'DATASET' instead
+- 'tileDataUrl' and 'tileAttributions' keys on the top level in ./initial-data-load/data/{country}/GeoData.yml configuration file are now deprecated. Use 'apiUrl' key instead of 'tileDataUrl' key and 'metadata.description' key instead of 'tileAttributions' key. You can find out more about these settings in [docs](./doc/data-structures/config-files.md#geoData.yml).
 
 ### Removed
 

--- a/api/src/database/mongoDb/dbSchemas/constants.ts
+++ b/api/src/database/mongoDb/dbSchemas/constants.ts
@@ -1,2 +1,2 @@
-export const LAYER_TYPES = ['points', 'regions', 'geometry', 'combined'];
-export const GEO_FORMATS = ['geojson'];
+export const LAYER_TYPES = ['points', 'regions', 'geometry', 'combined', 'tile'];
+export const GEO_FORMATS = ['geojson', 'tiles'];

--- a/api/src/database/mongoDb/dbSchemas/metadataSchema.ts
+++ b/api/src/database/mongoDb/dbSchemas/metadataSchema.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 const MetadataSchema = new mongoose.Schema(
   {
     description: String,
+    attributions: String,
     sourceWebsite: String,
     sourceOrganisation: String,
     updateDate: String,

--- a/doc/data-structures/config-files.md
+++ b/doc/data-structures/config-files.md
@@ -77,6 +77,7 @@ _with geodata file provided by url to publicly available source_
   geometryDataTypes: types of geographical data
   metadata: information about the geographical data in file
     description: String
+    attributions: String
     sourceWebsite: String
     sourceOrganization: String
     updateDate: String
@@ -99,6 +100,7 @@ _or with geodata file provided in folder './initial-data-load/data/{COUNTRY}/geo
   geometryDataTypes: types of geographical data
   metadata: information about the geographical data in file
     description: String
+    attributions: String
     sourceWebsite: String
     sourceOrganization: String
     updateDate: String
@@ -147,6 +149,7 @@ This config file is one long array with settings for layers in map. As there are
 **metadata**: informations about data in layer, they are shown when you click on info button aside from map layer in layers menu
 
 - **description**:,
+- **attributions**: attributions of the layer data source,
 - **sourceWebsite**:,
 - **sourceOrganisation**:,
 - **updateDate**:,

--- a/doc/data-structures/in-database.md
+++ b/doc/data-structures/in-database.md
@@ -25,6 +25,7 @@ attributeIds: list of all available Features properties
 geometryDataTypes: types of geographical data
 metadata: information about the geographical data in file
   description: String
+  attributions: String
   sourceWebsite: String
   sourceOrganization: String
   updateDate: String
@@ -47,6 +48,7 @@ attributeIds: list of all available Features properties
 geometryDataTypes: types of geographical data
 metadata: information about the geographical data in file
   description: String
+  attributions: String
   sourceWebsite: String
   sourceOrganization: String
   updateDate: String

--- a/frontend/src/components/LayerInfoModal.js
+++ b/frontend/src/components/LayerInfoModal.js
@@ -69,6 +69,16 @@ const LayerInfoModal = ({ isOpen, handleModalClose, modalData, title }) => {
               </Grid>
             </Grid>
           )}
+          {modalData.attributions && (
+            <Grid container item xs={12} spacing={2} className={classes.modalRow}>
+              <Grid item xs={12} sm={4} className={classes.modalRowLabel}>
+                Attributions
+              </Grid>
+              <Grid item xs={12} sm={8} className={classes.modalRowDescription}>
+                {modalData.attributions}
+              </Grid>
+            </Grid>
+          )}
           {modalData.sourceWebsite && (
             <Grid container item xs={12} spacing={2} className={classes.modalRow}>
               <Grid item xs={12} sm={4} className={classes.modalRowLabel}>
@@ -165,6 +175,16 @@ const LayerInfoModal = ({ isOpen, handleModalClose, modalData, title }) => {
                   </Grid>
                   <Grid item xs={12} sm={8} className={classes.modalRowDescription}>
                     {modalData.geoMetadata.description}
+                  </Grid>
+                </Grid>
+              )}
+              {modalData.geoMetadata.attributions && (
+                <Grid container item xs={12} spacing={2} className={classes.modalRow}>
+                  <Grid item xs={12} sm={4} className={classes.modalRowLabel}>
+                    Attributions
+                  </Grid>
+                  <Grid item xs={12} sm={8} className={classes.modalRowDescription}>
+                    {modalData.geoMetadata.attributions}
                   </Grid>
                 </Grid>
               )}

--- a/frontend/src/ol/staticLayers/layerTypes/tiles.js
+++ b/frontend/src/ol/staticLayers/layerTypes/tiles.js
@@ -12,7 +12,7 @@ const tileLayer = (layerData) => {
       url: layerData.tileDataUrl || layerData.geoDataUrl,
       attributions:
         layerData.tileAttributions ||
-        (layerData.metadata && layerData.metadata.geoMetadata && layerData.metadata.geoMetadata.description),
+        (layerData.metadata && layerData.metadata.geoMetadata && layerData.metadata.geoMetadata.attributions),
     }),
     zIndex: 0,
     layerOptions: layerData.layerOptions,

--- a/frontend/src/ol/staticLayers/layerTypes/tiles.js
+++ b/frontend/src/ol/staticLayers/layerTypes/tiles.js
@@ -9,8 +9,10 @@ const tileLayer = (layerData) => {
     featureId: layerData.featureId,
     type: layerData.layerType,
     source: new XYZ({
-      url: layerData.tileDataUrl,
-      attributions: layerData.tileAttributions,
+      url: layerData.tileDataUrl || layerData.geoDataUrl,
+      attributions:
+        layerData.tileAttributions ||
+        (layerData.metadata && layerData.metadata.geoMetadata && layerData.metadata.geoMetadata.description),
     }),
     zIndex: 0,
     layerOptions: layerData.layerOptions,

--- a/initial-data-load/src/database/mongoDb/schemas/metadataSchema.ts
+++ b/initial-data-load/src/database/mongoDb/schemas/metadataSchema.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 const MetadataSchema = new mongoose.Schema(
   {
     description: String,
+    attributions: String,
     sourceWebsite: String,
     sourceOrganisation: String,
     updateDate: String,

--- a/initial-data-load/src/mapLayers/constants.ts
+++ b/initial-data-load/src/mapLayers/constants.ts
@@ -1,2 +1,2 @@
-export const LAYER_TYPES = ['points', 'regions', 'geometry', 'combined'];
-export const GEO_FORMATS = ['geojson'];
+export const LAYER_TYPES = ['points', 'regions', 'geometry', 'combined', 'tile'];
+export const GEO_FORMATS = ['geojson', 'tiles'];

--- a/initial-data-load/src/mapLayers/layersGeoDataUpload.ts
+++ b/initial-data-load/src/mapLayers/layersGeoDataUpload.ts
@@ -92,7 +92,6 @@ const formatLayerGeoData = async (data: GeoDataConfigItem, dataset: string) => {
     if (hasFile && data.storeToDb) {
       logger.info(`Storing geodata ${data.geoDataFilename} for layer ${data.referenceId} from file...`);
       await storeGeoDataToDb(true, data, filePath);
-      url = data.apiUrl;
       logger.info(`Layer ${data.name} has new URL for geodata: ${url}`);
     } else if (hasFile && !data.storeToDb) {
       logger.info(`Storing geojson ${data.geoDataFilename} for layer ${data.referenceId} from file...`);

--- a/initial-data-load/src/types.ts
+++ b/initial-data-load/src/types.ts
@@ -26,6 +26,7 @@ export interface GeoJson {
 
 export interface Metadata {
   description?: string;
+  attributions?: string;
   sourceWebsite?: string;
   sourceOrganisation?: string;
   updateDate: string;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!--- Provide a general summary of the issue in the Title above -->

## Description

- geodata schema updated so we can use "tiles" in format and "tile" in geometryDataTypes in GeoData config. Also added notice to changelog, that tileDataUrl and tileAttributions are being deprecated and changed FE according to this. 

## Motivation and Context

- after mongoDB refactor to Postgresql, the filter in layers is changed(for postgre version) so now it expect all layers to have georeferenceId Point and Tile layers included, so geoData are needed for these layers now and we need format and layer type for Tile layer
- this change also affected other part of code, so now we can use 'apiUrl' key instead of 'tileDataUrl' key and 'metadata.description' key instead of 'tileAttributions' key so tileDataUrl and tileAttributions are being deprecated
- after merging this branch, create a new release if possible

##  How to test
- add metadata attributions prop to MapLayers and GeoData config, run app and initial load and see if you can find them in map info.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have checked to ensure that there aren't other open [Pull Requests](../../../pulls) for the same update/change.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
